### PR TITLE
Use correct regional route for SEA account-v1

### DIFF
--- a/orianna/src/main/java/com/merakianalytics/orianna/datapipeline/riotapi/RiotAPIService.java
+++ b/orianna/src/main/java/com/merakianalytics/orianna/datapipeline/riotapi/RiotAPIService.java
@@ -691,7 +691,7 @@ public class RiotAPIService extends AbstractDataSource {
 
     private <T extends DataObject> T get(final RequestContext<T> context) {
         context.attemptCount += 1;
-        final String platform = context.isRegionalRequest ? context.platform.getRegionalRoute().toLowerCase() : context.platform.getTag().toLowerCase();
+        final String platform = context.isRegionalRequest ? context.platform.getRegionalRoute(context.endpoint).toLowerCase() : context.platform.getTag().toLowerCase();
         final String host = platform + ".api.riotgames.com";
 
         Response response = null;

--- a/orianna/src/main/java/com/merakianalytics/orianna/types/common/Platform.java
+++ b/orianna/src/main/java/com/merakianalytics/orianna/types/common/Platform.java
@@ -82,5 +82,12 @@ public enum Platform {
         return Versions.withPlatform(this).get();
     }
 
-    public String getRegionalRoute() { return regionalRoute; }
+    public String getRegionalRoute(String endpoint) {
+        // "There are three routing values for account-v1; americas, asia, and europe. You can query for any account in
+        // any region. We recommend using the nearest cluster." - https://developer.riotgames.com/apis#account-v1/
+        if (endpoint.startsWith("riot/account/v1/") && regionalRoute.equalsIgnoreCase("SEA")) {
+            return JAPAN.regionalRoute;
+        }
+        return regionalRoute;
+    }
 }


### PR DESCRIPTION
"There are three routing values for account-v1; americas, asia, and europe. You can query for any account in any region. We recommend using the nearest cluster."

 https://developer.riotgames.com/apis#account-v1/
